### PR TITLE
Fixed image plugin size problems.

### DIFF
--- a/PopcornEditor/src/plugins/image/popcorn.image.css
+++ b/PopcornEditor/src/plugins/image/popcorn.image.css
@@ -1,4 +1,4 @@
-.image-plugin-container {
+.image-plugin-container, .image-plugin-container.ui-resizable {
   position: absolute;
 }
 .image-plugin-container.track-event-editing .clone-container {


### PR DESCRIPTION
More specific & inclusive css for image plugin container. Directives for ui-resizable in additional jquery-ui css were stealing the show.

Fixes #64.
