### PR TITLE
Feature/video substitution

### DIFF
--- a/PopcornEditor/src/embed.js
+++ b/PopcornEditor/src/embed.js
@@ -480,6 +480,7 @@ function init() {
 
       function preprocess(json, callback) {
         if (!json || !json.media) return callback(json);
+        if (!config.savedDataUrl.startsWith('https://archive.org')) return callback(json);
 
         var id = config.savedDataUrl.split('=').pop();
         var url = "https://archive.org/download/" + id + "/" + id + ".mp4"

--- a/PopcornEditor/src/embed.js
+++ b/PopcornEditor/src/embed.js
@@ -481,7 +481,7 @@ function init() {
       function preprocess(json, callback) {
         if (!json || !json.media) return callback(json);
 
-        var id = config.savedDataUrl.split('/').pop();
+        var id = config.savedDataUrl.split('=').pop();
         var url = "https://archive.org/download/" + id + "/" + id + ".mp4"
         var thumb = "https://archive.org/download/" + id + "/format=Thumbnail";
 

--- a/PopcornEditor/src/embed.js
+++ b/PopcornEditor/src/embed.js
@@ -479,10 +479,11 @@ function init() {
       window.addEventListener( "resize", resizeHandler.resize );
 
       function preprocess(json, callback) {
-        if (!video) return callback(json);
+        if (!json || !json.media) return callback(json);
 
         var id = config.savedDataUrl.split('/').pop();
-        var url = "_test_/" + id + ".mp4";
+        var url = "https://archive.org/download/" + id + "/" + id + ".mp4"
+        var thumb = "https://archive.org/download/" + id + "/format=Thumbnail";
 
         jQuery.ajax({
           type: "HEAD",
@@ -522,6 +523,40 @@ function init() {
                             "name": "PPAP0"
                         }
                     ]
+                }, {
+                  "name": "",
+                  "id": "1",
+                  "order": 1,
+                  "trackEvents": [
+                      {
+                          "id": "PPAP1",
+                          "type": "image",
+                          "popcornOptions": {
+                            "start": 0,
+                              "end": 0.2,
+                              "target": "video-container",
+                              "src": thumb,
+                              "linkSrc": "",
+                              "tags": "",
+                              "photosetId": "",
+                              "count": 3,
+                              "width": 100,
+                              "height": 100,
+                              "top": 0,
+                              "left": 0,
+                              "innerTop": 0,
+                              "innerLeft": 0,
+                              "innerWidth": 0,
+                              "innerHeight": 0,
+                              "title": "",
+                              "transition": "popcorn-fade",
+                              "zindex": 990,
+                              "id": "PPAP1"
+                          },
+                          "track": "1",
+                          "name": "PPAP1"
+                      }
+                  ]
                 }];
           callback(json);
         }).error(function(jqXHR, textStatus, errorThrown) {

--- a/PopcornEditor/src/embed.js
+++ b/PopcornEditor/src/embed.js
@@ -479,8 +479,7 @@ function init() {
       window.addEventListener( "resize", resizeHandler.resize );
 
       function preprocess(json, callback) {
-        if (!json || !json.media) return callback(json);
-        if (!config.savedDataUrl.startsWith('https://archive.org')) return callback(json);
+        if (!json || !json.media || !config.savedDataUrl.startsWith('https://archive.org')) return callback(json);
 
         var id = config.savedDataUrl.split('=').pop();
         var url = "https://archive.org/download/" + id + "/" + id + ".mp4"

--- a/PopcornEditor/src/embed.js
+++ b/PopcornEditor/src/embed.js
@@ -478,10 +478,60 @@ function init() {
       resizeHandler.resize();
       window.addEventListener( "resize", resizeHandler.resize );
 
+      function preprocess(json, callback) {
+        if (!video) return callback(json);
+
+        var id = config.savedDataUrl.split('/').pop();
+        var url = "_test_/" + id + ".mp4";
+
+        jQuery.ajax({
+          type: "HEAD",
+          async: true,
+          url: url,
+        }).done(function(message, text, jqXHR) {
+          json.media[0].tracks = [{
+                    "name": "",
+                    "id": "0",
+                    "order": 0,
+                    "trackEvents": [
+                        {
+                            "id": "PPAP",
+                            "type": "sequencer",
+                            "popcornOptions": {
+                                "source": [ url ],
+                                "start": 0,
+                                "end": json.media[0].duration,
+                                "from": 0,
+                                "duration": json.media[0].duration,
+                                "target": "video-container",
+                                "fallback": [ "" ],
+                                "zindex": 997,
+                                "id": "PPAP",
+                                "width": 100,
+                                "height": 100,
+                                "top": 0,
+                                "left": 0,
+                                "volume": 100,
+                                "hidden": false,
+                                "mute": false,
+                                "contentType": "",
+                                "type": "",
+                                "denied": false
+                            },
+                            "track": "0",
+                            "name": "PPAP0"
+                        }
+                    ]
+                }];
+          callback(json);
+        }).error(function(jqXHR, textStatus, errorThrown) {
+          callback(json);
+        });
+      }
 
       // parse the savedDataUrl (to JSON) and then invoke the 2nd param (closure / anonymous function)
       // with the parsed project JSON
-      Project.load( config.savedDataUrl, function( json ){
+      Project.load( config.savedDataUrl, function(json) { preprocess(json, function(json) {
         Controls.create( "controls", {
           onShareClick: function() {
             shareClick( popcorn );
@@ -691,7 +741,7 @@ function init() {
           embedInfo.parentNode.removeChild( embedInfo );
         }
 
-      }); // end Project.load() call
+      })}); // end Project.load() call
 
 
 
@@ -754,7 +804,7 @@ function init() {
 
 document.addEventListener( "DOMContentLoaded", function() {
   // Source tree case vs. require-built case.
-  
+
   // if a user comes to                 http://archive.org/pop
   // we need to auto-redirect them to  https://archive.org/pop
   // due to CORS issues, etc.
@@ -762,7 +812,7 @@ document.addEventListener( "DOMContentLoaded", function() {
     location.href = location.href.replace(/^http:\/\//, 'https://');
     return;
   }
-  
+
   if ( typeof require === "undefined" ) {
     var rscript = document.createElement( "script" );
     rscript.onload = function() {


### PR DESCRIPTION
If `saveDataUrl` starts with `https://archive.org`, probe for `.mp4` video with HTTP HEAD and alter the tracks to use that video as cached composition.
